### PR TITLE
lifetime bugfix

### DIFF
--- a/src/convenience_api.rs
+++ b/src/convenience_api.rs
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(Duration::from_millis(5568), mw.duration().unwrap());
         assert_eq!("MPEG-4", mw.format().unwrap());
         assert_eq!("Base Media / Version 2", mw.format_profile().unwrap());
-        assert_eq!("MPEG-4", mw.codec().unwrap());
+        assert!(mw.codec().is_err(), "Codec should be empty");
         assert_eq!(551194, mw.overall_bit_rate().unwrap());
         assert_eq!("HandBrake 0.9.4 2009112300", mw.writing_application().unwrap());
         assert_eq!(160, mw.headersize().unwrap());

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -114,12 +114,11 @@ impl MediaInfo {
             if param_w_string.is_err(){ return Err(MediaInfoError::RustToCStringError); }
             if value_w_string.is_err(){ return Err(MediaInfoError::RustToCStringError); }
 
-            let param_ptr = param_w_string.unwrap().as_raw();
-            let value_ptr = value_w_string.unwrap().as_raw();
-
             // TODO(erick): Do we need to free this memory? I could not
             // find this information on the documentation.
-            let result_ptr = MediaInfo_Option(self.handle, param_ptr, value_ptr);
+            let result_ptr = MediaInfo_Option(self.handle,
+                                              param_w_string.unwrap().as_raw(),
+                                              value_w_string.unwrap().as_raw());
             let result_c_string = CWcharString::from_raw_to_c_string(result_ptr);
             if result_c_string.is_err() { return Err(MediaInfoError::CToRustError); }
 
@@ -165,12 +164,11 @@ impl MediaInfo {
             let param_w_string = CWcharString::from_str(parameter);
             if param_w_string.is_err(){ return Err(MediaInfoError::RustToCStringError); }
 
-            let param_ptr = param_w_string.unwrap().as_raw();
-
             // TODO(erick): Do we need to free this memory? I could not
             // find this information on the documentation.
             let result_ptr = MediaInfo_Get(self.handle, info_stream.c_compatible(),
-                                           stream_number as size_t, param_ptr,
+                                           stream_number as size_t,
+                                           param_w_string.unwrap().as_raw(),
                                            info_kind.c_compatible(),
                                            search_kind.c_compatible());
             let result_c_string = CWcharString::from_raw_to_c_string(result_ptr);


### PR DESCRIPTION
The lifetime of "param_w_string.unwrap()" is shorter than the lifetime of "param_w_string.unwrap().as_raw()".
Thus, after "let param_ptr = param_w_string.unwrap().as_raw();", the pointed value seems not to be available anymore, and the call to "MediaInfo_Get" returns an empty string.